### PR TITLE
add missing attachment type

### DIFF
--- a/src/types/attachment.ts
+++ b/src/types/attachment.ts
@@ -1,41 +1,48 @@
 export interface Attachment {
     /**
-     * 
+     *
      * @type {AttachmentType}
      * @memberof Attachment
      * @description The type of attachment.
      */
     type: AttachmentType;
     /**
-     * 
+     *
+     * @type {string}
+     * @memberof Attachment
+     * @description The text of the attachment.
+     */
+    text?: string;
+    /**
+     *
      * @type {string}
      * @memberof Attachment
      * @description The title of the attachment.
      */
     title?: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof Attachment
      * @description The description of the attachment.
      */
     description?: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof Attachment
      * @description The URL of the attachment if it is of the link type.
      */
     url?: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof Attachment
      * @description The identifier of the file in the external system. Read-only, and only provided by some systems.
      */
     file_external_id?: string;
     /**
-     * 
+     *
      * @type {number}
      * @memberof Attachment
      * @description The size of the file in bytes. Read-only, and only provided by some systems.
@@ -43,11 +50,12 @@ export interface Attachment {
     size?: number;
 }
 
-
 /**
  * @export
  * @enum {string}
  */
 export enum AttachmentType {
-    Link = 'link'
+    Link = 'link',
+    Text = 'text',
+    File = 'file'
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,6 @@
     // error out if import and file system have a casing mismatch. Recommended by TS
     "forceConsistentCasingInFileNames": true,
     // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
-    "noEmit": true,
+    "noEmit": true
   }
 }


### PR DESCRIPTION
adds properties and enum values for the missing attachment type `text`