### PR TITLE
Update audit event types and endpoints for the new scope format.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.3",
+  "version": "2.0.4",
   "repository": "https://github.com/edlink/edlink-node-sdk",
   "license": "Unlicense",
   "main": "dist/index.js",

--- a/src/common/audit_event.ts
+++ b/src/common/audit_event.ts
@@ -8,15 +8,6 @@ export class AuditEvents {
     }
 
     /**
-     * Paginates through all Events within a given scope.
-     * @param scope_id An arbitrary string identifier for the scope (e.g. a tenant or customer ID)
-     * @param options Provide a `limit` for the max number of results
-     */
-    async *list(scope_id: string, options: RequestOptionsPaging = {}): AsyncGenerator<AuditEvent> {
-        yield* this.api.paginate<AuditEvent>(`/events/scope/${scope_id}`, options);
-    }
-
-    /**
      * Fetches a single Event by ID.
      * @param event_id The UUID of the Event
      * @returns The requested Event

--- a/src/common/audit_event.ts
+++ b/src/common/audit_event.ts
@@ -1,4 +1,4 @@
-import { Actor, AuditEvent, BearerTokenAPI, Context, RequestOptionsGet, RequestOptionsPaging, RequestOptionsPost, Scope, Target } from '../types';
+import { Actor, AuditEvent, BearerTokenAPI, Context, RequestOptionsGet, RequestOptionsPaging, RequestOptionsPost, Target, UUID } from '../types';
 
 export class AuditEvents {
     constructor(private api: BearerTokenAPI) {
@@ -9,12 +9,11 @@ export class AuditEvents {
 
     /**
      * Paginates through all Events within a given scope.
-     * @param scope_type The type of scope, either `integration` or `institution`
-     * @param scope_id The UUID of the scope
+     * @param scope_id An arbitrary string identifier for the scope (e.g. a tenant or customer ID)
      * @param options Provide a `limit` for the max number of results
      */
-    async *list(scope_type: string, scope_id: string, options: RequestOptionsPaging = {}): AsyncGenerator<AuditEvent> {
-        yield* this.api.paginate<AuditEvent>(`/events/${scope_type}/${scope_id}`, options);
+    async *list(scope_id: string, options: RequestOptionsPaging = {}): AsyncGenerator<AuditEvent> {
+        yield* this.api.paginate<AuditEvent>(`/events/scope/${scope_id}`, options);
     }
 
     /**
@@ -33,7 +32,7 @@ export class AuditEvents {
      * @returns The recorded Event's assigned ID
      */
     create(
-        event: { actor: Actor; action: string; targets: Target[]; scope: Scope; context?: Context; data?: any },
+        event: { actor: Actor; action: string; targets: Target[]; scope: string; institution?: UUID; context?: Context; data?: any },
         options: RequestOptionsPost = {},
     ): Promise<Pick<AuditEvent, 'id'>> {
         return this.api.request({

--- a/src/types/audit_event.ts
+++ b/src/types/audit_event.ts
@@ -9,16 +9,12 @@ export enum CRUDXType {
   Delete = "delete",
   Other = "other",
 }
-type UUID = `${string}-${string}-${string}-${string}-${string}`;
-
-export enum ScopeType {
-    Institution = "institution",
-    Integration = "integration",
-}
+export type UUID = `${string}-${string}-${string}-${string}-${string}`;
 
 export interface AuditIdentifier {
     value: string;
     issuer: string;
+    name?: string;
 }
 
 export interface Actor {
@@ -31,11 +27,6 @@ export interface Target {
     type: string;
     identifiers: AuditIdentifier[];
     details?: object;
-}
-
-export interface Scope {
-    id: UUID;
-    type: ScopeType;
 }
 
 export interface SchemaRef {
@@ -106,11 +97,18 @@ export interface AuditEvent {
      */
     targets: Target[];
     /**
-     * The scope (integration or institution) the Event belongs to.
-     * @type {Scope}
+     * The user-defined scope the Event belongs to.
+     * An arbitrary string identifier (up to 128 bytes) internal to your system.
+     * @type {string}
      * @memberof AuditEvent
      */
-    scope: Scope;
+    scope: string;
+    /**
+     * The Edlink Public-Data API 'institution' the Event belongs to.
+     * @type {UUID}
+     * @memberof AuditEvent
+     */
+    institution?: UUID;
     /**
      * Information about the underlying network request. Strongly suggested.
      * @type {Context}

--- a/src/types/audit_event.ts
+++ b/src/types/audit_event.ts
@@ -18,7 +18,7 @@ export interface AuditIdentifier {
 }
 
 export interface Actor {
-    type: "person" | "system" | "external";
+    type: "person" | "system" | "anonymous";
     identifiers: AuditIdentifier[];
     details?: object;
 }
@@ -45,7 +45,7 @@ export interface Context {
     hostname?: string;
     os?: string;
     environment?: string;
-    trigger?: "person" | "system" | "external";
+    trigger?: "person" | "system" | "anonymous";
     deployment_id?: string;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,4 @@
 export * from './api';
-export * from './audit_schema';
 export * from './audit_event';
 export * from './common';
 export * from './address';

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -12,8 +12,6 @@ import {
     TokenSetType,
     IntegrationTokenSet,
     ApplicationTokenSet,
-    ScopeType,
-    CRUDXType,
     Agent,
     PersonTokenSet,
 } from '../src';
@@ -452,9 +450,6 @@ if (process.env.APPLICATION_SECRET_KEY) {
 
     describe('Audit', () => {
         let created_event_id: string;
-        let created_schema_id: string;
-        let created_schema_action: string;
-        let created_schema_event_id: string;
 
         it('POST /api/v2/audit/events', async () => {
             const result = await edlink.use(application_token_set).events.create({
@@ -464,12 +459,9 @@ if (process.env.APPLICATION_SECRET_KEY) {
                 },
                 action: 'user.login',
                 targets: [
-                    { type: 'session', identifiers: [{ value: 'session_abc', issuer: 'test' }] }
+                    { type: 'session', identifiers: [{ value: 'session_abc', issuer: 'test', name: 'Test Session' }] }
                 ],
-                scope: {
-                    id: process.env.AUDIT_SCOPE_ID! as `${string}-${string}-${string}-${string}-${string}`,
-                    type: ScopeType.Integration
-                },
+                scope: process.env.AUDIT_SCOPE_ID!,
                 context: {
                     http_method: 'POST',
                     path: '/login',
@@ -500,9 +492,9 @@ if (process.env.APPLICATION_SECRET_KEY) {
             expect(event.created_date).toBeDefined();
         });
 
-        it('GET /api/v2/audit/events/:scope_type/:scope_id', async () => {
+        it('GET /api/v2/audit/events/scope/:scope_id', async () => {
             let found = false;
-            for await (const event of edlink.use(application_token_set).events.list('integration', process.env.AUDIT_SCOPE_ID!, { limit: 25 })) {
+            for await (const event of edlink.use(application_token_set).events.list(process.env.AUDIT_SCOPE_ID!, { limit: 25 })) {
                 expect(event).toBeDefined();
                 expect(event.id).toBeDefined();
                 expect(event.action).toBeDefined();
@@ -513,99 +505,8 @@ if (process.env.APPLICATION_SECRET_KEY) {
             expect(found).toBe(true);
         });
 
-        it('POST /api/v2/audit/schemas', async () => {
-            created_schema_action = `test.schema.${Date.now()}`;
-            const schema = await edlink.use(application_token_set).schemas.create(
-                { id: created_schema_action, type: CRUDXType.Create },
-                {
-                    type: 'object',
-                    properties: {
-                        test_field: { type: 'string', description: 'A test field' }
-                    },
-                    required: ['test_field']
-                },
-                'lax'
-            );
-            expect(schema).toBeDefined();
-            expect(schema.id).toBeDefined();
-            expect(schema.action.id).toBe(created_schema_action);
-            expect(schema.action.type).toBe(CRUDXType.Create);
-            expect(schema.validation_level).toBe('lax');
-            created_schema_id = schema.id;
-        });
-
-        it('GET /api/v2/audit/schemas/:schema_id_or_action (by id)', async () => {
-            const schema = await edlink.use(application_token_set).schemas.fetch(created_schema_id);
-            expect(schema).toBeDefined();
-            expect(schema.id).toBe(created_schema_id);
-            expect(schema.action.id).toBe(created_schema_action);
-            expect(schema.action.type).toBe(CRUDXType.Create);
-            expect(schema.validation_level).toBe('lax');
-        });
-
-        it('GET /api/v2/audit/schemas/:schema_id_or_action (by action)', async () => {
-            const schema = await edlink.use(application_token_set).schemas.fetch(created_schema_action);
-            expect(schema).toBeDefined();
-            expect(schema.id).toBe(created_schema_id);
-            expect(schema.action.id).toBe(created_schema_action);
-        });
-
-        it('PATCH /api/v2/audit/schemas', async () => {
-            const schema = await edlink.use(application_token_set).schemas.update(
-                created_schema_action,
-                {
-                    action_type: CRUDXType.Other,
-                    validation_level: 'strict',
-                    data: {
-                        type: 'object',
-                        properties: {
-                            test_field: { type: 'string', description: 'A test field' },
-                            extra_field: { type: 'number', description: 'An extra field' }
-                        },
-                        required: ['test_field']
-                    }
-                }
-            );
-            expect(schema).toBeDefined();
-            expect(schema.id).toBe(created_schema_id);
-            expect(schema.action.id).toBe(created_schema_action);
-            expect(schema.action.type).toBe(CRUDXType.Other);
-            expect(schema.validation_level).toBe('strict');
-        });
-
-        it('POST /api/v2/audit/events (with schema)', async () => {
-            const result = await edlink.use(application_token_set).events.create({
-                actor: {
-                    type: 'system',
-                    identifiers: [{ value: 'test_system_1', issuer: 'test' }]
-                },
-                action: created_schema_action,
-                targets: [
-                    { type: 'resource', identifiers: [{ value: 'resource_xyz', issuer: 'test' }] }
-                ],
-                scope: {
-                    id: process.env.AUDIT_SCOPE_ID! as `${string}-${string}-${string}-${string}-${string}`,
-                    type: ScopeType.Integration
-                },
-                data: { test_field: 'hello from schema test' }
-            });
-            expect(result).toBeDefined();
-            expect(result.id).toBeDefined();
-            created_schema_event_id = result.id!;
-            await new Promise((r) => setTimeout(r, 3000));
-        });
-
-        it('GET /api/v2/audit/events/:event_id (schema id present)', async () => {
-            const event = await edlink.use(application_token_set).events.fetch(created_schema_event_id);
-            expect(event).toBeDefined();
-            expect(event.id).toBe(created_schema_event_id);
-            expect(event.action).toBe(created_schema_action);
-            expect(event.schema).toBeDefined();
-            expect(event.schema?.id).toBe(created_schema_id);
-        });
-
-        it('GET /api/v2/audit/events/:scope_type/:scope_id with action filter', async () => {
-            for await (const event of edlink.use(application_token_set).events.list('integration', process.env.AUDIT_SCOPE_ID!, { limit: 5, filter: { action: [{operator: 'equals', value: 'user.login' }]} })) {
+        it('GET /api/v2/audit/events/scope/:scope_id with action filter', async () => {
+            for await (const event of edlink.use(application_token_set).events.list(process.env.AUDIT_SCOPE_ID!, { limit: 5, filter: { action: [{operator: 'equals', value: 'user.login' }]} })) {
                 expect(event.action).toBe('user.login');
             }
         });

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -491,25 +491,6 @@ if (process.env.APPLICATION_SECRET_KEY) {
             expect(event.scope).toBeDefined();
             expect(event.created_date).toBeDefined();
         });
-
-        it('GET /api/v2/audit/events/scope/:scope_id', async () => {
-            let found = false;
-            for await (const event of edlink.use(application_token_set).events.list(process.env.AUDIT_SCOPE_ID!, { limit: 25 })) {
-                expect(event).toBeDefined();
-                expect(event.id).toBeDefined();
-                expect(event.action).toBeDefined();
-                if (event.id === created_event_id) {
-                    found = true;
-                }
-            }
-            expect(found).toBe(true);
-        });
-
-        it('GET /api/v2/audit/events/scope/:scope_id with action filter', async () => {
-            for await (const event of edlink.use(application_token_set).events.list(process.env.AUDIT_SCOPE_ID!, { limit: 5, filter: { action: [{operator: 'equals', value: 'user.login' }]} })) {
-                expect(event.action).toBe('user.login');
-            }
-        });
     });
 } else {
     console.error('APPLICATION_SECRET_KEY is not set, skipping Audit tests');


### PR DESCRIPTION
Align list/create APIs with string scopes, optional institution, and identifier names; drop leftover schema export and tests.